### PR TITLE
[feat| #54] 리스트사이드바 상단 필터링 반응형으로 구현

### DIFF
--- a/src/pages/listPage/ListPage.vue
+++ b/src/pages/listPage/ListPage.vue
@@ -4,6 +4,7 @@
       <ListSideBar
         :categories="categories"
         :transactions="transactions"
+        :filtered-transactions="filteredTransactions"
         @filter-change="handleFilterChange"
       />
     </div>

--- a/src/pages/listPage/_components/ListSideBar.vue
+++ b/src/pages/listPage/_components/ListSideBar.vue
@@ -93,6 +93,7 @@ import BtnDual from '@/components/button/BtnDual.vue'
 import backButton from '@/assets/icons/IconArrowBack.svg'
 import forwardButton from '@/assets/icons/IconArrowForward.svg'
 
+
 const props = defineProps({
   categories: Array,
   transactions: Array,

--- a/src/pages/listPage/_components/ListSideBar.vue
+++ b/src/pages/listPage/_components/ListSideBar.vue
@@ -3,7 +3,7 @@
     <!-- 월 이동 -->
     <div class="month-nav">
       <img :src="backButton" alt="back" @click="handlePrev" />
-      <span class="titleBold24px"> {{ monthText }} </span>
+      <span class="titleBold24px"> {{ rangeText }} </span>
       <img :src="forwardButton" alt="forward" @click="handleNext" />
     </div>
 
@@ -11,16 +11,16 @@
     <div class="summary">
       <div class="bodyRegular16px">
         💰 수입:
-        <span style="color: var(--color-dark)"> {{ monthlyIncome.toLocaleString() }}원 </span>
+        <span style="color: var(--color-dark)"> {{ totalIncome.toLocaleString() }}원 </span>
       </div>
       <div class="bodyRegular16px">
         💸 지출:
-        <span style="color: var(--color-dark)"> {{ monthlyExpense.toLocaleString() }}원 </span>
+        <span style="color: var(--color-dark)"> {{ totalExpense.toLocaleString() }}원 </span>
       </div>
       <div class="bodySemibold18px" style="margin-top: 0.5rem">
         총합:
         <span :class="totalColorClass">
-          {{ (monthlyIncome - monthlyExpense).toLocaleString() }}
+          {{ netTotal.toLocaleString() }}
         </span>
         원
       </div>
@@ -96,6 +96,7 @@ import forwardButton from '@/assets/icons/IconArrowForward.svg'
 const props = defineProps({
   categories: Array,
   transactions: Array,
+  filteredTransactions: Array,
 })
 const emit = defineEmits(['filter-change'])
 
@@ -111,14 +112,56 @@ const selectedExpense = ref([])
 
 const options = ['1주', '1개월', '3개월']
 
-const monthText = computed(() => `${currentDate.value.month() + 1}월`)
+const rangeText = computed(() => {
+  const date = currentDate.value
+
+  if (selectedRange.value === '1주') {
+    const start = date.day() === 0 ? date.subtract(6, 'day') : date.subtract(date.day() - 1, 'day')
+    const end = start.add(6, 'day')
+    return `${start.format('M/D')} ~ ${end.format('M/D')}`
+  }
+
+  if (selectedRange.value === '1개월') {
+    if(date.year()=='2025') {
+      return `${date.month() + 1}월`
+    } else {
+      return `${date.year()}년 `+`${date.month() + 1}월`
+    }
+  }
+
+  if (selectedRange.value === '3개월') {
+    const start = date.subtract(2, 'month')
+    return `${start.month() + 1}월 ~ ${date.month() + 1}월`
+  }
+
+  return ''
+})
+
+const totalIncome = computed(() =>
+  props.filteredTransactions
+    .filter((t) => t.type === 'Income')
+    .reduce((sum, t) => sum + t.amount, 0)
+)
+const totalExpense = computed(() =>
+  props.filteredTransactions
+    .filter((t) => t.type === 'Expense')
+    .reduce((sum, t) => sum + t.amount, 0)
+)
+const netTotal = computed(() => totalIncome.value - totalExpense.value)
+const totalColorClass = computed(() =>
+  netTotal.value > 0 ? 'color-positive' : netTotal.value < 0 ? 'color-negative' : ''
+)
 
 const handlePrev = () => {
-  currentDate.value = currentDate.value.subtract(1, 'month')
+  if (selectedRange.value === '1주') currentDate.value = currentDate.value.subtract(1, 'week')
+  else if (selectedRange.value === '1개월') currentDate.value = currentDate.value.subtract(1, 'month')
+  else if (selectedRange.value === '3개월') currentDate.value = currentDate.value.subtract(3, 'month')
   emitFilters()
 }
 const handleNext = () => {
-  currentDate.value = currentDate.value.add(1, 'month')
+  if (selectedRange.value === '1주') currentDate.value = currentDate.value.add(1, 'week')
+  else if (selectedRange.value === '1개월') currentDate.value = currentDate.value.add(1, 'month')
+  else if (selectedRange.value === '3개월') currentDate.value = currentDate.value.add(3, 'month')
   emitFilters()
 }
 
@@ -154,6 +197,7 @@ const selectIncome = (id) => {
   }
   emitFilters()
 }
+
 const selectExpense = (id) => {
   if (selectedExpense.value.includes(id)) {
     selectedExpense.value = selectedExpense.value.filter((i) => i !== id)
@@ -168,22 +212,7 @@ const selectExpense = (id) => {
 const incomeCategories = computed(() => props.categories.filter((c) => c.type === 'Income'))
 const expenseCategories = computed(() => props.categories.filter((c) => c.type === 'Expense'))
 
-const monthlyIncome = computed(() => {
-  const ym = currentDate.value.format('YYYY-MM')
-  return props.transactions
-    .filter((t) => t.type === 'Income' && t.date.startsWith(ym))
-    .reduce((sum, t) => sum + t.amount, 0)
-})
-const monthlyExpense = computed(() => {
-  const ym = currentDate.value.format('YYYY-MM')
-  return props.transactions
-    .filter((t) => t.type === 'Expense' && t.date.startsWith(ym))
-    .reduce((sum, t) => sum + t.amount, 0)
-})
-const totalColorClass = computed(() => {
-  const net = monthlyIncome.value - monthlyExpense.value
-  return net > 0 ? 'color-positive' : net < 0 ? 'color-negative' : ''
-})
+
 
 // 필터 상태 상위 컴포넌트로 전달
 const emitFilters = () => {


### PR DESCRIPTION
## Description
리스트페이지에서 왼쪽 사이드바의 날짜, 총합 등 데이터가 필터링에 반응하게 구현했습니다.

## Screenshot
![image](https://github.com/user-attachments/assets/f6df2f8e-a9ea-40c4-962b-2a832c907665)
![image](https://github.com/user-attachments/assets/4ee7a7a2-31ff-435c-a209-2fd43d114c86)
![image](https://github.com/user-attachments/assets/5728a2f2-ac4d-4682-90bf-82096750ca3d)


## Issue
- Resolved: #54 

## Check
- [x] npm run build 오류 없나요?
- [x] 코드 에러는 없나요?
