### PR TITLE
[fix| #78] 거래목록 시간 최신순으로 정렬 오류 수정

### DIFF
--- a/db.json
+++ b/db.json
@@ -418,6 +418,24 @@
       "date": "2025-04-05T11:18:00",
       "memo": "",
       "id": "9b8f"
+    },
+    {
+      "id": "7786",
+      "title": "11",
+      "category_id": "8888",
+      "type": "Expense",
+      "amount": 11,
+      "date": "2025-04-10T16:09:50",
+      "memo": "1"
+    },
+    {
+      "id": "51bb",
+      "title": "11ㄹㄹ",
+      "category_id": "3333",
+      "type": "Income",
+      "amount": 213,
+      "date": "2025-04-10T09:10:00",
+      "memo": ""
     }
   ],
   "quickAddOptions": [

--- a/src/pages/listPage/_components/ListSideBar.vue
+++ b/src/pages/listPage/_components/ListSideBar.vue
@@ -3,7 +3,7 @@
     <!-- 월 이동 -->
     <div class="month-nav">
       <img :src="backButton" alt="back" @click="handlePrev" />
-      <span class="titleBold24px"> {{ rangeText }} </span>
+      <span class="titleBold24px range-text" @click="resetToToday" > {{ rangeText }} </span>
       <img :src="forwardButton" alt="forward" @click="handleNext" />
     </div>
 
@@ -129,6 +129,13 @@ const selectedExpense = ref([])
 
 const options = ['1주', '1개월', '3개월']
 
+function resetToToday() {
+  
+  currentDate.value = dayjs()
+  selectedRange.value = '1개월'
+  resetFilters()
+}
+
 const rangeText = computed(() => {
   const date = currentDate.value
 
@@ -242,6 +249,7 @@ const emitFilters = () => {
     expenseCategoryIds: selectedExpense.value,
   })
 }
+
 </script>
 
 <style scoped>
@@ -337,5 +345,8 @@ const emitFilters = () => {
   font-weight: 600;
   text-decoration: underline;
   text-underline-offset: 0.25rem;
+}
+.range-text {
+  cursor: pointer;
 }
 </style>

--- a/src/pages/listPage/_components/TransactionOneDay.vue
+++ b/src/pages/listPage/_components/TransactionOneDay.vue
@@ -5,7 +5,7 @@
       <div class="summary bodyRegular16px">{{ formattedTotal }} {{ items.length }}건</div>
     </div>
     <div class="items">
-      <ListItem v-for="item in items" :key="item.id" :item="item" :categoryMap="categoryMap" />
+      <ListItem v-for="item in sortedItems" :key="item.id" :item="item" :categoryMap="categoryMap" />
     </div>
   </div>
 </template>
@@ -37,6 +37,12 @@ const formattedTotal = computed(() => {
   const sign = total.value >= 0 ? '+' : '-'
   return `${sign}${Math.abs(total.value).toLocaleString()}원`
 })
+
+const sortedItems = computed(() =>
+  [...props.items].sort((a, b) => {
+    return dayjs(b.date).valueOf() - dayjs(a.date).valueOf()
+  })
+)
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Description
- 거래 목록 시간순 정렬 오류 수정(저녁 -> 새벽 순)
- 월 or 주 텍스트 클릭시 오늘로 이동 기능 추가

## Screenshot
![image](https://github.com/user-attachments/assets/99b398c3-0032-403a-b48f-b514d96265f7)


## Issue
- Resolved: #78 

## Check
- [x] npm run build 오류 없나요?
- [x] 코드 에러는 없나요?
