### PR TITLE
[fix | #103] 페이지 이동시 차트 데이터 초기화

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -126,32 +126,48 @@ const monthlyTotal = computed(() => {
 // 소비,수입,트랜잭션 그룹화
 const grouped = computed(() => {
   const map = new Map()
-  // 날짜별로 그룹핑
-  lineFilteredTransactions.value.forEach((tx) => {
-    const date = tx.date
-    const isIncome = tx.type === 'Income'
 
-    // 해당 날짜 없으면 초기화
-    if (!map.has(date)) {
-      map.set(date, {
-        income: 0,
-        incomeCount: 0,
-        expense: 0,
-        expenseCount: 0,
-      })
-    }
-    // 해당 날짜 있으면 업데이트
-    const entry = map.get(date)
-    if (isIncome) {
+  // 범위 설정
+  const now = new Date(currentLineDate.value)
+  const start = subtractPeriod(now, periodLine.value, 1)
+
+  const days = []
+  const cursor = new Date(start)
+  while (cursor <= now) {
+    const ymd = cursor.toISOString().split('T')[0]
+    days.push(ymd)
+    cursor.setDate(cursor.getDate() + 1)
+  }
+
+  // 날짜 초기화 설정
+  days.forEach((ymd) => {
+    map.set(ymd, {
+      income: 0,
+      incomeCount: 0,
+      expense: 0,
+      expenseCount: 0,
+    })
+  })
+
+  // 트랜잭션 데이터 그룹화
+  lineFilteredTransactions.value.forEach((tx) => {
+    const ymd = new Date(tx.date).toISOString().split('T')[0]
+
+    if (!map.has(ymd)) return
+    const entry = map.get(ymd)
+
+    if (tx.type === 'Income') {
       entry.income += tx.amount
       entry.incomeCount++
-    } else {
+    } else if (tx.type === 'Expense') {
       entry.expense += tx.amount
       entry.expenseCount++
     }
   })
 
+  // 날짜별로 정렬
   const sorted = [...map.entries()].sort(([a], [b]) => a.localeCompare(b))
+
   return {
     labels: sorted.map(([date]) => date),
     incomeData: sorted.map(([, val]) => val.income),

--- a/src/components/chart/Line.vue
+++ b/src/components/chart/Line.vue
@@ -59,8 +59,13 @@ const options = computed(() => ({
   xaxis: {
     categories: props.labels,
     labels: {
-      // 라벨 형식 mm/dd 형식으로 변환
       formatter: function (value) {
+        const idx = props.labels.indexOf(value)
+        const income = props.incomeData[idx] || 0
+        const expense = props.expenseData[idx] || 0
+
+        if (income === 0 && expense === 0) return '' // 라벨 숨김
+
         const date = new Date(value)
         const mm = String(date.getMonth() + 1).padStart(2, '0')
         const dd = String(date.getDate()).padStart(2, '0')

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="report-divider"></div>
     <div class="report-title titleBold24px">
-      <RouterLink :to="{ name: 'report' }">1개월 소비리포트</RouterLink>
+      <RouterLink :to="{ name: 'report' }">이번달 소비리포트</RouterLink>
     </div>
     <div class="report-wrapper bodySemibold18px">
       <div class="report-left">

--- a/src/pages/reportPage/_components/DoughnutExplain.vue
+++ b/src/pages/reportPage/_components/DoughnutExplain.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { inject, computed, onMounted, onUnmounted } from 'vue'
 import BtnDual from '@/components/button/BtnDual.vue'
 import BtnXs from '@/components/button/BtnXs.vue'
 import backButton from '@/assets/icons/IconArrowBack.svg'
@@ -49,6 +49,13 @@ const currentDate = inject('currentDoughnutDate')
 const setCurrentDate = inject('setCurrentDoughnutDate')
 const transactions = inject('transactions')
 const subtractPeriod = inject('subtractPeriod')
+
+onMounted(() => {
+  setCurrentDate(new Date())
+  periodDoughnut.value = '1개월'
+  isIncome.value = false
+  isExpense.value = true
+})
 
 function formatDateYMD(date) {
   return date.toISOString().split('T')[0]
@@ -132,6 +139,13 @@ function resetToToday() {
   setCurrentDate(new Date())
   periodDoughnut.value = '1개월'
 }
+
+onUnmounted(() => {
+  setCurrentDate(new Date())
+  periodDoughnut.value = '1개월'
+  isIncome.value = false
+  isExpense.value = true
+})
 </script>
 
 <style scoped>

--- a/src/pages/reportPage/_components/LineExplain.vue
+++ b/src/pages/reportPage/_components/LineExplain.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { inject, computed, onMounted, onUnmounted } from 'vue'
 import BtnXs from '@/components/button/BtnXs.vue'
 import backButton from '@/assets/icons/IconArrowBack.svg'
 import forwardButton from '@/assets/icons/IconArrowForward.svg'
@@ -43,6 +43,11 @@ const currentDate = inject('currentLineDate')
 const setCurrentDate = inject('setCurrentLineDate')
 const transactions = inject('transactions')
 const subtractPeriod = inject('subtractPeriod')
+
+onMounted(() => {
+  setCurrentDate(new Date())
+  periodLine.value = '1개월'
+})
 
 function formatDateYMD(date) {
   return date.toISOString().split('T')[0]
@@ -126,6 +131,11 @@ function resetToToday() {
   setCurrentDate(new Date())
   periodLine.value = '1개월'
 }
+
+onUnmounted(() => {
+  setCurrentDate(new Date())
+  periodLine.value = '1개월'
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Description
<!-- 설명을 작성하세요. -->
데이터 있는 날만 라벨 보여지게 하고 페이지 이동시에 같이 연동되는 점 해지

## Screenshot
<!-- 화면 스크린샷 찍어주세요. -->
![image](https://github.com/user-attachments/assets/f1c66200-5f50-4135-a033-6295ae03bc0d)


## Issue
- Resolved: #103

## Check
- [x] npm run build 오류 없나요?
- [x] 코드 에러는 없나요?
